### PR TITLE
updated readme with a more complete example (closes #1) and fixed errors (closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,93 +21,13 @@ const userConnections = {
       TableName: 'users',
       ...paginationToParams(args)
     })
-    .then(data => {
-      return dataToConnection(data)
-    });
+    .then(dataToConnection);
   })
 };
 ```
 
-### And a more complete example using native ES2015 Node.js features
+a more complete example using native ES2015 Node.js features and be found [here](examples/schema.js)
 
-```js
-'use strict';
-
-const AWS = require('aws-sdk')
-
-const GraphQLObjectType = require('graphql').GraphQLObjectType
-const GraphQLSchema = require('graphql').GraphQLSchema
-const GraphQLString = require('graphql').GraphQLString
-const GraphQLNonNull = require('graphql').GraphQLNonNull
-const GraphQLID = require('graphql').GraphQLID
-
-
-const connectionArgs = require('graphql-relay').connectionArgs
-const connectionDefinitions = require('graphql-relay').connectionDefinitions
-
-const paginationToParams = require('graphql-dynamodb-connections').paginationToParams
-const dataToConnection = require('graphql-dynamodb-connections').dataToConnection
-
-const dynamoConfig = {
-  sessionToken:    process.env.AWS_SESSION_TOKEN,
-  region:          process.env.AWS_REGION
-}
-
-const docClient = new AWS.DynamoDB.DocumentClient(dynamoConfig)
-
-const store = {}
-
-const Store = new GraphQLObjectType({
-  name: 'Store',
-  fields: () => ({
-    linkConnection: {
-      type: linkConnection.connectionType,
-      args: connectionArgs,
-      resolve: (_, args) => {
-        return docClient.scan(
-          Object.assign(
-            {},
-            {TableName: 'links'},
-            paginationToParams(args)
-          )
-        ).promise().then(dataToConnection)
-      }
-    }
-  })
-})
-
-const Link = new GraphQLObjectType({
-  name: 'Link',
-  fields: () => ({
-    id: {
-      type: new GraphQLNonNull(GraphQLID),
-      resolve: (obj) => obj.id
-    },
-    title: { type: GraphQLString },
-    url: { type: GraphQLString }
-  })
-})
-
-const linkConnection = connectionDefinitions({
-  name: 'Link',
-  nodeType: Link
-})
-
-const schema = new GraphQLSchema({
-  query: new GraphQLObjectType({
-    name: 'Query',
-    fields: () => ({
-      store: {
-        type: Store,
-        resolve: () => store
-      }
-    })
-  })
-})
-
-module.exports = schema
-
-```
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,96 @@ const userConnections = {
   type: userConnection,
   args: connectionArgs,
   resolve: ((_, args) => {
-    promisifiedDocumentClient.scan({
+    return promisifiedDocumentClient.scan({
       TableName: 'users',
       ...paginationToParams(args)
     })
-    .then(data => dataToConnection(data));
+    .then(data => {
+      return dataToConnection(data)
+    });
   })
 };
+```
+
+### And a more complete example using native ES2015 Node.js features
+
+```js
+'use strict';
+
+const AWS = require('aws-sdk')
+
+const GraphQLObjectType = require('graphql').GraphQLObjectType
+const GraphQLSchema = require('graphql').GraphQLSchema
+const GraphQLString = require('graphql').GraphQLString
+const GraphQLNonNull = require('graphql').GraphQLNonNull
+const GraphQLID = require('graphql').GraphQLID
+
+
+const connectionArgs = require('graphql-relay').connectionArgs
+const connectionDefinitions = require('graphql-relay').connectionDefinitions
+
+const paginationToParams = require('graphql-dynamodb-connections').paginationToParams
+const dataToConnection = require('graphql-dynamodb-connections').dataToConnection
+
+const dynamoConfig = {
+  sessionToken:    process.env.AWS_SESSION_TOKEN,
+  region:          process.env.AWS_REGION
+}
+
+const docClient = new AWS.DynamoDB.DocumentClient(dynamoConfig)
+
+const store = {}
+
+const Store = new GraphQLObjectType({
+  name: 'Store',
+  fields: () => ({
+    linkConnection: {
+      type: linkConnection.connectionType,
+      args: connectionArgs,
+      resolve: (_, args) => {
+        return docClient.scan(
+          Object.assign(
+            {},
+            {TableName: 'links'},
+            paginationToParams(args)
+          )
+        ).promise().then(dataToConnection)
+      }
+    }
+  })
+})
+
+const Link = new GraphQLObjectType({
+  name: 'Link',
+  fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLID),
+      resolve: (obj) => obj.id
+    },
+    title: { type: GraphQLString },
+    url: { type: GraphQLString }
+  })
+})
+
+const linkConnection = connectionDefinitions({
+  name: 'Link',
+  nodeType: Link
+})
+
+const schema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: 'Query',
+    fields: () => ({
+      store: {
+        type: Store,
+        resolve: () => store
+      }
+    })
+  })
+})
+
+module.exports = schema
+
 ```
 
 ## API

--- a/examples/schema.js
+++ b/examples/schema.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * This example shows how to use relay, graphql and dynamoDB with AWS lambda
+ * - It uses native ES2015 Node.js (v4.3.2) features
+ * - It uses graphql-dynamodb-connections to convert DynamoDB-style pagination to GraphQL Connection-style pagination
+ */
+
+const AWS = require('aws-sdk')
+
+const GraphQLObjectType = require('graphql').GraphQLObjectType
+const GraphQLSchema = require('graphql').GraphQLSchema
+const GraphQLString = require('graphql').GraphQLString
+const GraphQLNonNull = require('graphql').GraphQLNonNull
+const GraphQLID = require('graphql').GraphQLID
+
+
+const connectionArgs = require('graphql-relay').connectionArgs
+const connectionDefinitions = require('graphql-relay').connectionDefinitions
+
+const paginationToParams = require('graphql-dynamodb-connections').paginationToParams
+const dataToConnection = require('graphql-dynamodb-connections').dataToConnection
+
+const dynamoConfig = {
+  sessionToken:    process.env.AWS_SESSION_TOKEN,
+  region:          process.env.AWS_REGION
+}
+
+const docClient = new AWS.DynamoDB.DocumentClient(dynamoConfig)
+
+const store = {}
+
+const Store = new GraphQLObjectType({
+  name: 'Store',
+  fields: () => ({
+    linkConnection: {
+      type: linkConnection.connectionType,
+      args: connectionArgs,
+      resolve: (_, args) => {
+        return docClient.scan(
+          Object.assign(
+            {},
+            {TableName: 'links'},
+            paginationToParams(args)
+          )
+        ).promise().then(dataToConnection)
+      }
+    }
+  })
+})
+
+const Link = new GraphQLObjectType({
+  name: 'Link',
+  fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLID),
+      resolve: (obj) => obj.id
+    },
+    title: { type: GraphQLString },
+    url: { type: GraphQLString }
+  })
+})
+
+const linkConnection = connectionDefinitions({
+  name: 'Link',
+  nodeType: Link
+})
+
+const schema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: 'Query',
+    fields: () => ({
+      store: {
+        type: Store,
+        resolve: () => store
+      }
+    })
+  })
+})
+
+module.exports = schema
+


### PR DESCRIPTION
This fixes issues #1 and #2 

Note that AWS SDK supports promises out of the box and in a more complete example I only used ES2015 Node.js features that are available natively (Node.js version 4.3.2, because that is the latest version currently supported in AWS Lambda) , because setting up webpack and babel in aws lambda/dynamoDB environment is quite tricky, especially for beginners, so this example would get them started quickly.
